### PR TITLE
✨ Add cooldown activity

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -45,6 +45,7 @@ const workoutsTypes = {
   HKWorkoutActivityTypeBowling: 'bowling',
   HKWorkoutActivityTypeBoxing: 'boxing',
   HKWorkoutActivityTypeClimbing: 'climbing',
+  HKWorkoutActivityTypeCooldown: 'cooldown',
   HKWorkoutActivityTypeCoreTraining: 'core',
   HKWorkoutActivityTypeCricket: 'cricket',
   HKWorkoutActivityTypeCrossCountrySkiing: 'cross-country-skiing',


### PR DESCRIPTION
# Problem

I got the `HKWorkoutActivityTypeNonExistingActivityType` error while running `npm start export.zip` :

```
Exploring your data. It will take some time, please wait...
apple-watch-workouts-year-review/lib/mapper.js:122
    throw new Error(`${workoutActivityType} workoutActivityType not handled yet`)
    ^

Error: HKWorkoutActivityTypeCooldown workoutActivityType not handled yet
```

## Proposition

Add it.

## Note

Definition of the activity according to the [documentation](https://developer.apple.com/documentation/healthkit/hkworkoutactivitytype/hkworkoutactivitytypecooldown) :
> _The constant for low intensity stretching and mobility exercises following a more vigorous workout._