### PR TITLE
✨ Grafana working with InfluxQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
     container_name: apple_watch_grafana
     ports:
       - "3000:3000"
+    environment:
+      - APPLE_WATCH_INFLUX_BUCKET=$APPLE_WATCH_INFLUX_BUCKET
+      - APPLE_WATCH_INFLUX_TOKEN=$APPLE_WATCH_INFLUX_TOKEN
     links:
       - influxdb
     volumes:

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -10,13 +10,12 @@ datasources:
     access: proxy
     orgId: 1
     url: http://apple_watch_influxdb:8086
+    database: $APPLE_WATCH_INFLUX_BUCKET
     jsonData:
-      version: Flux
-      organization: my_org
-      defaultBucket: apple_watch
-      tlsSkipVerify: true
+      httpHeaderName1: 'Authorization'
+      timeInterval: 1d
     secureJsonData:
-      token: my_token
+      httpHeaderValue1: 'Token $APPLE_WATCH_INFLUX_TOKEN'
     isDefault: true
     editable: true
     options:


### PR DESCRIPTION
Setup InfluxDB 2.x datasource for InfluxQL.

Pass environment variables to the `apple_watch_grafana` container for use in the datasource configuration file.